### PR TITLE
update project single view to be responsive

### DIFF
--- a/assets/css/project/_alt_goal.styl
+++ b/assets/css/project/_alt_goal.styl
@@ -1,6 +1,6 @@
 .alt-goal
   group()
-  padding: 120px 0
+  padding: 120px 0 120px 20px
   position: relative
 
   .img
@@ -26,3 +26,24 @@
     max-width: 143px
     width: 100%
     font-size: .74em
+
+  +below('xl')
+    padding-top: 70px
+    padding-bottom: 70px
+
+    .img
+      max-width: 50%
+
+    .copy
+      max-width: 40%
+
+  +below('s')
+    .img
+      max-width: 100%
+      float: none
+
+    .copy
+      max-width: 100%
+      position: static
+      transform: translateY(0)
+      padding-top: 5px

--- a/assets/css/project/_description.styl
+++ b/assets/css/project/_description.styl
@@ -1,5 +1,5 @@
 #description
-  padding: 113px 0
+  padding: 113px 20px
 
   p
     font-size: 2.2em
@@ -10,3 +10,11 @@
     hover-darken()
     font-weight: 500
     transition: color .5s
+
+  +below('s')
+    padding-top: 30px
+    padding-bottom: 30px
+
+  +below('m')
+    padding-top: 70px
+    padding-bottom: 70px

--- a/assets/css/project/_full_image.styl
+++ b/assets/css/project/_full_image.styl
@@ -1,6 +1,5 @@
 .full-image
-  background-color: light-gray
-  background-size: 1400px 585px
-  background-position: center
-  background-repeat: no-repeat
-  min-height: 585px
+  img
+    max-width: 1400px
+    margin: 0 auto
+    width: 100%

--- a/assets/css/project/_goal.styl
+++ b/assets/css/project/_goal.styl
@@ -13,7 +13,7 @@
   .img
     float: left
     display: block
-    width: 530px
+    width: 38%
     background-color: gray
 
     img
@@ -23,10 +23,28 @@
   .copy
     absolute: top 50%
     transform: translateY(-50%)
-    max-width: 550px
-    width: 100%
+    width: 50%
     box-sizing: content-box
     inline-block()
     vertical-align: middle
-    padding-left: 160px
+    padding-left: 8%
+    // padding-left: 160px
 
+
+  +below('l')
+    padding: 80px 20px
+
+  +below('s')
+    padding-top: 30px
+    padding-bottom: 30px
+
+    .img
+      float: none
+      width: 100%
+
+    .copy
+      position: static
+      transform: translateY(0)
+      width: 100%
+      padding-top: 5px
+      padding-left: 0

--- a/assets/css/project/_slideshow.styl
+++ b/assets/css/project/_slideshow.styl
@@ -1,22 +1,19 @@
 .slideshow
-  padding: 90px 0
-
-  &.alt
-    background-color: gallery-bg
+  padding: 90px 20px
 
   h3
     color: seafoam
 
   .img
     display: block
-    min-height: 500px
     padding: 30px 0
+    margin: 0 auto
 
   button
     slideshow-btn-width = 12px
     slideshow-btn-height = 24px
     absolute: top 50%
-    margin-top: -(slideshow-btn-height / 2)
+    transform: translateY(-50%)
     size: slideshow-btn-width slideshow-btn-height
     background-size: slideshow-btn-width slideshow-btn-height
     background-repeat: no-repeat
@@ -34,3 +31,14 @@
     &.slick-next
       right: -25px
       background-image: url('/img/icons/slide-arrow-right.svg')
+
+  +below('xs')
+    padding-top: 40px
+    padding-bottom: 40px
+
+    .img
+      max-width: 80%
+
+  @media (max-width: 1150px)
+    .img
+      max-width: 90%

--- a/assets/css/project/_takeaway.styl
+++ b/assets/css/project/_takeaway.styl
@@ -1,7 +1,7 @@
 #takeaway
   background-color: seafoam
   color: white
-  padding: 105px 0 65px
+  padding: 105px 20px 65px
 
   .wrap
     position: relative
@@ -48,3 +48,18 @@
 
   .next
     float: right
+
+  +below('l')
+    padding-top: 65px
+    padding-bottom: 25px
+
+  +below('s')
+    .controls
+      span
+        display: none
+
+      a
+        min-width: 20px
+
+    .next
+      text-align: right

--- a/assets/css/project/_title.styl
+++ b/assets/css/project/_title.styl
@@ -2,6 +2,10 @@
   border-top: 1px solid title-border-gray
   padding: 70px 0 50px
 
+  .wrap
+    box-sizing: content-box
+    padding: 0 20px
+
   h1
     color: seafoam
     text-transform: uppercase
@@ -27,3 +31,6 @@
     max-width: 100px
     border-top: 1px
     border-color: seafoam
+
+  .wrap
+    box-sizing: content-box

--- a/projects/_template.jade
+++ b/projects/_template.jade
@@ -15,7 +15,8 @@ block content
         h3= post.h3
         hr
 
-    .full-image(style= bg_img(project_img(post.hero_img), post.hero_img_bg_color))
+    .full-image(style= bg_color(post.hero_img_bg_color))
+      img(src= project_img(post.hero_img))
 
     #description
       .wrap
@@ -40,14 +41,15 @@ block content
 
       else if m.type == 'full-image'
         .full-image(style= bg_img(project_img(m.img), m.bg_color))
+          img(src= project_img(m.img))
 
       else if m.type == 'alt-goal'
         .alt-goal(style= bg_color(m.bg_color))
           .wrap
-            .copy
-              != marked(m.copy)
             .img
               img(src= project_img(m.img))
+            .copy
+              != marked(m.copy)
 
     #takeaway
       .wrap


### PR DESCRIPTION
This makes the project single page views responsive. There is probably some adjustment that could still be done with font sizing and smaller sizes etc. 

If you wanna take a peek, this uses [rupture](https://github.com/jenius/rupture), a handy way of doing media queries using stylus mixins such as `+below('xs')`, `+above('m')` to apply different styles. If you're curious, the breakpoints being used are the default ones specified in [rupture here](https://github.com/jenius/rupture#rupturescale-names)

Closes #27 
