### PR TITLE
order projects using data/order.yaml, ref #25

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -4,7 +4,9 @@ autoprefixer    = require 'autoprefixer-stylus'
 js_pipeline     = require 'js-pipeline'
 css_pipeline    = require 'css-pipeline'
 dynamic_content = require 'dynamic-content'
+yaml            = require 'roots-yaml'
 marked          = require 'marked'
+_               = require 'lodash'
 
 module.exports =
   ignores: [
@@ -13,6 +15,7 @@ module.exports =
     ]
 
   extensions: [
+    yaml()
     dynamic_content()
     js_pipeline(files: 'assets/js/*.coffee')
     css_pipeline(files: 'assets/css/*.styl')
@@ -46,6 +49,9 @@ module.exports =
     bg_color: (color = '#fff') ->
       if color == 'dark' then color = '#f5f5f5'
       "background-color: #{color};"
+    sort_projects: (projects, order) ->
+      _.map order, (k) ->
+        _.find(projects, (p) -> p._url == "/projects/#{k}.html")
 
   server:
     clean_urls: true

--- a/data/order.yaml
+++ b/data/order.yaml
@@ -1,0 +1,6 @@
+- giving
+- greatest_hotels
+- sounds
+- beak_skiff
+- dearborn
+- knee_therapy

--- a/package.json
+++ b/package.json
@@ -6,14 +6,15 @@
     "axis": "0.3.x",
     "coffee-script": "1.8.x",
     "css-pipeline": "0.2.x",
+    "dynamic-content": "0.2.x",
     "jade": "1.x",
     "js-pipeline": "0.2.x",
-    "marked": "0.3.x",
-    "rupture": "0.6.x",
-    "stylus": "0.49.x",
-    "roots": "3.0.x",
     "lodash": "3.1.x",
-    "dynamic-content": "0.2.x"
+    "marked": "0.3.x",
+    "roots": "3.0.x",
+    "roots-yaml": "0.0.4",
+    "rupture": "0.6.x",
+    "stylus": "0.49.x"
   },
   "scripts": {
     "ship": "roots deploy -to netlify"

--- a/views/index.jade
+++ b/views/index.jade
@@ -13,7 +13,7 @@ block content
     #gallery
       .wrap
         ul
-          - each p in site.projects
+          - each p in sort_projects(site.projects, data.order)
             li: .wrapper
               a(href= p._url)
                 img(src= project_img(p.thumbnail))


### PR DESCRIPTION
Uses `data/order.yaml` to keep order of the projects. the file name is used in `order.yaml` to determine the order in the index view. ref #25 
